### PR TITLE
Configuration changes composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
 
     "require": {
-        "php": ">=5.3",
-        "ulrichsg/getopt-php": "*"
+        "php": ">=5.5",
+        "ulrichsg/getopt-php": "1.4.*"
     },
 
     "autoload": {


### PR DESCRIPTION
It did not work if there is a problem such as the following.
1. getopt-php version
   When it is version **1.1.0**, ulrichsg/getopt-php become to **2.2.0**, can not be performed.
2. PHP Version
   if there is a part that uses a **finally block**, I did not work only in **PHP5.5**.
   [http://www.php.net/manual/en/language.exceptions.php](http://www.php.net/manual/en/language.exceptions.php)
   
   In PHP 5.5 and later, a finally block may also be specified after
   the catch blocks. Code within the finally block will always be executed after the try
   and catch blocks, regardless of whether an exception has been thrown, and before normal
   execution resumes.

I want you to change the setting of composer.json.
The current configuration has to use the following.

  "require": {
      "php": ">=5.3",
      "ulrichsg/getopt-php": "*"
  },

I have changed as follows.

  "require": {
      "php": ">=5.5",
      "ulrichsg/getopt-php": "1.4.*"
  },
